### PR TITLE
추가화면 클릭이벤트 구현

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -52,6 +52,7 @@ dependencies {
     implementation "androidx.fragment:fragment-ktx:$ktx_version"
 
     testImplementation 'junit:junit:4.13.2'
+    testImplementation "androidx.arch.core:core-testing:2.1.0"
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
 }

--- a/app/src/main/java/com/gdsc/todo/Event.kt
+++ b/app/src/main/java/com/gdsc/todo/Event.kt
@@ -1,0 +1,19 @@
+package com.gdsc.todo
+
+open class Event<out T>(private val content: T) {
+
+    var hasBeenHandled = false
+    private set
+
+    fun getContentIfNotHandled(): T? = when(hasBeenHandled) {
+        true -> {
+            null
+        }
+        false -> {
+            hasBeenHandled = true
+            content
+        }
+    }
+
+    fun peekContent() = content
+}

--- a/app/src/main/java/com/gdsc/todo/ui/ToDoViewModel.kt
+++ b/app/src/main/java/com/gdsc/todo/ui/ToDoViewModel.kt
@@ -1,5 +1,7 @@
 package com.gdsc.todo.ui
 
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import com.gdsc.todo.model.ToDo
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -13,10 +15,19 @@ class ToDoViewModel @Inject constructor(
     private var _toDoList: MutableList<ToDo> = mutableListOf()
     val toDoList: List<ToDo> = _toDoList
 
+    // TODO: Event 객체를 만들어 Unit을 감쌀 것.
+    private var _addButtonClickEvent: MutableLiveData<Unit> = MutableLiveData()
+    val addButtonClickEvent: LiveData<Unit> = _addButtonClickEvent
+
     var title = ""
     var contents = ""
 
-    fun addToDoList() {
+    fun clickAddButton() {
+        _addButtonClickEvent.value = Unit
+        addToDoList()
+    }
+
+    private fun addToDoList() {
         _toDoList.add(ToDo(title, contents))
     }
 }

--- a/app/src/main/java/com/gdsc/todo/ui/ToDoViewModel.kt
+++ b/app/src/main/java/com/gdsc/todo/ui/ToDoViewModel.kt
@@ -3,6 +3,7 @@ package com.gdsc.todo.ui
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
+import com.gdsc.todo.Event
 import com.gdsc.todo.model.ToDo
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
@@ -15,15 +16,14 @@ class ToDoViewModel @Inject constructor(
     private var _toDoList: MutableList<ToDo> = mutableListOf()
     val toDoList: List<ToDo> = _toDoList
 
-    // TODO: Event 객체를 만들어 Unit을 감쌀 것.
-    private var _addButtonClickEvent: MutableLiveData<Unit> = MutableLiveData()
-    val addButtonClickEvent: LiveData<Unit> = _addButtonClickEvent
+    private var _addButtonClickEvent: MutableLiveData<Event<Unit>> = MutableLiveData()
+    val addButtonClickEvent: LiveData<Event<Unit>> = _addButtonClickEvent
 
     var title = ""
     var contents = ""
 
     fun clickAddButton() {
-        _addButtonClickEvent.value = Unit
+        _addButtonClickEvent.value = Event(Unit)
         addToDoList()
     }
 

--- a/app/src/main/java/com/gdsc/todo/ui/addtodo/AddToDoActivity.kt
+++ b/app/src/main/java/com/gdsc/todo/ui/addtodo/AddToDoActivity.kt
@@ -22,11 +22,7 @@ class AddToDoActivity: BaseActivity<ActivityAddTodoBinding>(R.layout.activity_ad
 
     private fun setObserve() {
         viewModel.addButtonClickEvent.observe(this) {
-            navigateHomeActivity()
+            finish()
         }
-    }
-
-    private fun navigateHomeActivity() {
-        // TODO: home화면 전환
     }
 }

--- a/app/src/main/java/com/gdsc/todo/ui/addtodo/AddToDoActivity.kt
+++ b/app/src/main/java/com/gdsc/todo/ui/addtodo/AddToDoActivity.kt
@@ -21,8 +21,10 @@ class AddToDoActivity: BaseActivity<ActivityAddTodoBinding>(R.layout.activity_ad
     }
 
     private fun setObserve() {
-        viewModel.addButtonClickEvent.observe(this) {
-            finish()
+        viewModel.addButtonClickEvent.observe(this) { clickEvent ->
+            clickEvent.getContentIfNotHandled()?.let {
+                finish()
+            }
         }
     }
 }

--- a/app/src/main/java/com/gdsc/todo/ui/addtodo/AddToDoActivity.kt
+++ b/app/src/main/java/com/gdsc/todo/ui/addtodo/AddToDoActivity.kt
@@ -16,5 +16,17 @@ class AddToDoActivity: BaseActivity<ActivityAddTodoBinding>(R.layout.activity_ad
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         binding.vm = viewModel
+
+        setObserve()
+    }
+
+    private fun setObserve() {
+        viewModel.addButtonClickEvent.observe(this) {
+            navigateHomeActivity()
+        }
+    }
+
+    private fun navigateHomeActivity() {
+        // TODO: home화면 전환
     }
 }

--- a/app/src/main/res/layout/activity_add_todo.xml
+++ b/app/src/main/res/layout/activity_add_todo.xml
@@ -63,7 +63,7 @@
             android:layout_height="wrap_content"
             android:contentDescription="@string/complete_to_do"
             android:src="@drawable/ic_check"
-            android:onClick="@{() -> vm.addToDoList()}"
+            android:onClick="@{() -> vm.clickAddButton()}"
             app:tint="@color/white"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent">

--- a/app/src/test/java/com/gdsc/todo/ui/ToDoViewModelTest.kt
+++ b/app/src/test/java/com/gdsc/todo/ui/ToDoViewModelTest.kt
@@ -2,14 +2,19 @@ package com.gdsc.todo.ui
 
 import com.gdsc.todo.model.ToDo
 import org.junit.Assert.*
-
-import org.junit.After
+import androidx.arch.core.executor.testing.InstantTaskExecutorRule
 import org.junit.Before
+import org.junit.Rule
 import org.junit.Test
 
 class ToDoViewModelTest {
 
     private lateinit var viewModel: ToDoViewModel
+
+    @Rule
+    @JvmField
+    // LiveData가 Main Thread가 아니여도 set value를 할 수 있게 수정하는 테스트 룰
+    val rule = InstantTaskExecutorRule()
 
     @Before
     fun setUp() {
@@ -28,7 +33,7 @@ class ToDoViewModelTest {
         viewModel.contents = contents
 
         // And click FAB
-        viewModel.addToDoList()
+        viewModel.clickAddButton()
 
         // Then added To Do List
         assertEquals(todo, viewModel.toDoList[0])


### PR DESCRIPTION
## What is this pr
- Resolve: #28 
- [Single Live Event & event wrapper정리](https://cha-ji.tistory.com/entry/Android-Single-Live-Event-Event-wrapper)
## Changes
<!-- - pr에서 변경된 내용 -->
- event wrapper 클래스를 만들어 클릭 이벤트를 처리
- FAB 클릭 시 activity를 finish

## 고민과 해결
### 고민1
- LiveData는 main Thread(UI Thread)에서만 set value가 가능하다. test는 일반 kotlin 코드이기 때문에 main thread가 존재하지 않고 liveData가 항상 null이다.

### 해결
- test rule을 설정해 background thread에서도 set value가 가능하게 변경했다.

### 고민2
- FAB를 동시에 여러번 클릭하면 destroy된 activity에서 finish를 호출하는 등의 문제가 생길 것이다.

### 해결
- 해당 문제를 해결하기 위해서 Debounce, Throttle을 적용할 수도 있겠으나 일단은 Event Wrapper 클래스를 사용했으며 home 화면이 존재할 때 재차 실험해볼 예정이다.

### 고민3
1. FAB를 클릭하면 LiveData에 아무 값이나 Set Value를 한다. (구현한 방식에선 c언어의 void와 비슷한 Unit을 그대로 넣었다.)
2. Activity에서 observe해 화면전환을 한다.

- 위처럼 실행하면 화면이 회전되어  LiveData가 InActive -> Activate 상태가 될 때 set value가 된 것처럼 초기화된다.
- 클릭하지 않았지만 클릭된 효과가 생긴다.

### 해결
- [Single Live Event & event wrapper정리](https://cha-ji.tistory.com/entry/Android-Single-Live-Event-Event-wrapper)
